### PR TITLE
General enhancements around rate-limiting, logging, info processing and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,17 @@ options:
   --debug               Print debug info for target packages found at any version
   --repo-type {public,private}
                         Specify the type of repositories to scan: public or private (default: all)
+  --include-archived    Include archived repositories in scan (default: exclude archived repos)
 ```
 
 ## Examples
-
 ```
-# run for all repos
+# run for all repos (excluding archived by default)
 python dh.py --detector npm --account YOUR_ACCOUNT --versions versions.txt > report.md
 python dh.py --detector go --account YOUR_ACCOUNT --versions versions.txt > report.md
+
+# include archived repositories
+python dh.py --detector npm --account YOUR_ACCOUNT --versions versions.txt --include-archived > report.md
 
 # run separate scans for public/private repos
 python dh.py --detector npm --account YOUR_ACCOUNT --repo-type public --versions versions.txt > public_report.md

--- a/detectors/base_detector.py
+++ b/detectors/base_detector.py
@@ -1,11 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Dict, Optional
+from typing import List, Set, Tuple, Dict, Optional
 import requests
 
 
 class BaseDetector(ABC):
     @abstractmethod
-    def search_files(self, session: requests.Session, org: str, repo_full_name: str) -> List[dict]:
+    def search_files(self, session: requests.Session, org: str, repo_full_name: str) -> Tuple[List[dict], bool]:
+        pass
+
+    @abstractmethod
+    def process_repositories(self, session: requests.Session, org: str, repo_type: str, targets: List[Tuple[str, str]], include_archived: bool = False) -> Tuple[Set[str], List[dict], int, List[str]]:
         pass
 
     @abstractmethod

--- a/detectors/go_detector.py
+++ b/detectors/go_detector.py
@@ -1,122 +1,246 @@
 # Placeholder for Go dependency detection logic
 
-from typing import List, Tuple, Optional, Set, Dict
 import re
-import requests
 import sys
-from config import GITHUB_API
-import base64
 import time
-from utils.report_generator import make_markdown_report, print_table
-from utils.github_utils import list_all_repositories
+import base64
+from typing import List, Tuple, Optional, Set, Dict
+import requests
+from config import GITHUB_API
 from .base_detector import BaseDetector
-
-
-def parse_go_sum(go_sum_content: str) -> List[Tuple[str, str]]:
-    """
-    Parse the go.sum file content to extract module names and versions.
-    Returns a list of tuples (module, version).
-    """
-    pattern = re.compile(r"^([^\s]+)\s+([^\s]+)\s+\w+$")
-    dependencies = []
-    for line in go_sum_content.splitlines():
-        match = pattern.match(line)
-        if match:
-            module, version = match.groups()
-            dependencies.append((module, version))
-    return dependencies
+from utils.github_utils import list_all_repositories, http_get
+from utils.report_generator import print_table
 
 
 class GoDetector(BaseDetector):
+    def __init__(self):
+        self.search_delay = 2  # seconds between search requests
+        self.content_delay = 0.1  # seconds between content fetches
+
     def search_files(self, session: requests.Session, org: str, repo_full_name: str) -> List[dict]:
+        """
+        Search for go.sum using two strategies:
+        1. Code Search API (fast but may fail on large repos)
+        2. Contents API fallback (slower but reliable)
+        """
+        # Strategy 1: Try Code Search API first
+        items = self._search_via_code_api(session, repo_full_name)
+        
+        if items:
+            sys.stderr.write(f"[{repo_full_name}] Found {len(items)} go.sum file(s) via Code Search API\n")
+            return items
+        
+        # Strategy 2: Fallback to Contents API
+        sys.stderr.write(f"[{repo_full_name}] Code Search returned 0 results, trying Contents API...\n")
+        items = self._search_via_contents_api(session, repo_full_name)
+        
+        if items:
+            sys.stderr.write(f"[{repo_full_name}] Found {len(items)} go.sum file(s) via Contents API\n")
+        
+        return items
+
+    def _search_via_code_api(self, session: requests.Session, repo_full_name: str) -> List[dict]:
+        """Search using Code Search API (may fail on large repos)"""
         items = []
         page = 1
+        
         while True:
             params = {
-                "q": f"org:{org} repo:{repo_full_name} filename:go.sum",
+                "q": f"repo:{repo_full_name} filename:go.sum",
                 "per_page": 100,
                 "page": page,
             }
-            resp = session.get(f"{GITHUB_API}/search/code", params=params)
+            
+            resp = http_get(session, f"{GITHUB_API}/search/code", params=params)
+            
             if resp.status_code != 200:
-                sys.stderr.write(f"Search API error: {resp.status_code} {resp.text}\n")
+                if resp.status_code == 404:
+                    # Repository not found or not accessible
+                    break
+                sys.stderr.write(f"[{repo_full_name}] Search API error: {resp.status_code}\n")
                 break
+                
             data = resp.json()
             page_items = data.get("items", [])
-            # Filter to ensure only exact 'go.sum' files are processed
             page_items = [item for item in page_items if item.get("name") == "go.sum"]
+            
             if not page_items:
                 break
+                
             items.extend(page_items)
             page += 1
+            
+            if page_items:
+                time.sleep(self.search_delay)
+        
+        return items
+
+    def _search_via_contents_api(self, session: requests.Session, repo_full_name: str) -> List[dict]:
+        """
+        Fallback using Contents API.
+        Search in common locations used by Mattermost Go repositories.
+        """
+        items = []
+        
+        # Common paths in Mattermost Go repositories
+        common_paths = [
+            "",              # root (most Go projects)
+            "server",        # mattermost/mattermost
+            "cmd",           # command directories
+            "api",           # API services
+        ]
+        
+        not_found_count = 0
+        
+        for path in common_paths:
+            file_path = f"{path}/go.sum" if path else "go.sum"
+            url = f"{GITHUB_API}/repos/{repo_full_name}/contents/{file_path}"
+            
+            resp = http_get(session, url, suppress_404=True)
+            
+            if resp.status_code == 200:
+                data = resp.json()
+                
+                # Convert Contents API format to Search API format
+                item = {
+                    "name": "go.sum",
+                    "path": file_path,
+                    "sha": data.get("sha"),
+                    "url": data.get("url"),
+                    "html_url": data.get("html_url"),
+                    "repository": {
+                        "full_name": repo_full_name
+                    }
+                }
+                items.append(item)
+                sys.stderr.write(f"[{repo_full_name}] Found: {file_path}\n")
+            elif resp.status_code == 404:
+                not_found_count += 1
+            else:
+                # Log other errors
+                sys.stderr.write(f"[{repo_full_name}] Unexpected error {resp.status_code} while checking {file_path}\n")
+            
+            time.sleep(self.content_delay)
+        
+        # Show summary message if nothing was found
+        if not items and not_found_count > 0:
+            sys.stderr.write(f"[{repo_full_name}] Checked {len(common_paths)} common locations, no go.sum found\n")
+        
         return items
 
     def fetch_content(self, session: requests.Session, item: dict) -> Optional[str]:
+        """Fetch and decode the content of a file"""
         contents_url = item.get("url")
         sha = item.get("sha")
+        repo_full_name = item.get("repository", {}).get("full_name", "unknown")
+        path = item.get("path", "")
+        
         if not contents_url:
             repo = item.get("repository", {}).get("full_name")
-            path = item.get("path")
             if not repo or not path:
                 return None
             contents_url = f"{GITHUB_API}/repos/{repo}/contents/{path}"
 
         url = contents_url if "?" in contents_url else contents_url + (f"?ref={sha}" if sha else "")
 
-        resp = session.get(url)
+        resp = http_get(session, url)
+        
         if resp.status_code != 200:
-            sys.stderr.write(f"Failed to fetch contents: {resp.status_code} {url}\n")
+            sys.stderr.write(f"[{repo_full_name}] Failed to fetch {path}: HTTP {resp.status_code}\n")
             return None
 
         payload = resp.json()
         if not isinstance(payload, dict):
             return None
+            
         encoding = payload.get("encoding")
         content_b64 = payload.get("content")
+        
         if encoding != "base64" or not content_b64:
+            sys.stderr.write(f"[{repo_full_name}] Invalid encoding for {path}\n")
             return None
+            
         try:
             raw = base64.b64decode(content_b64).decode("utf-8", errors="replace")
             return raw
         except Exception as e:
-            sys.stderr.write(f"Error decoding/parsing content from {url}: {e}\n")
+            sys.stderr.write(f"[{repo_full_name}] Error decoding {path}: {e}\n")
             return None
 
     def parse_dependencies(self, content: str) -> List[Tuple[str, str]]:
-        return parse_go_sum(content)
+        """
+        Parse the go.sum file content to extract module names and versions.
+        Returns a list of tuples (module, version).
+        """
+        pattern = re.compile(r"^([^\s]+)\s+([^\s]+)\s+\w+$")
+        dependencies = []
+        
+        for line in content.splitlines():
+            match = pattern.match(line)
+            if match:
+                module, version = match.groups()
+                dependencies.append((module, version))
+                
+        return dependencies
 
     def find_matches(self, dependencies: List[Tuple[str, str]], targets: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
+        """Find dependencies matching target versions"""
         target_set = set(targets)
         return [(module, version) for module, version in dependencies if (module, version) in target_set]
 
-    def process_repositories(self, session: requests.Session, org: str, repo_type: str, targets: List[Tuple[str, str]]) -> Tuple[Set[str], List[dict], int]:
+    def process_repositories(self, session: requests.Session, org: str, repo_type: str, targets: List[Tuple[str, str]], include_archived: bool = False) -> Tuple[Set[str], List[dict], int, List[str]]:  # NUEVO: parámetro
+        """Process all repositories in the organization"""
         unique_repos: Set[str] = set()
         results: List[dict] = []
         total_files_scanned = 0
 
-        repos = list_all_repositories(session, org, repo_type)
+        sys.stderr.write(f"\n{'='*80}\n")
+        sys.stderr.write(f"Starting scan for organization: {org}\n")
+        sys.stderr.write(f"Repository type: {repo_type}\n")
+        sys.stderr.write(f"Target modules: {len(targets)}\n")
+        sys.stderr.write(f"Include archived: {include_archived}\n")  # NUEVO: log
+        sys.stderr.write(f"{'='*80}\n\n")
+
+        repos = list_all_repositories(session, org, repo_type, include_archived)  # NUEVO: pasar parámetro
         total_repos = len(repos)
+        
+        sys.stderr.write(f"Found {total_repos} repositories to scan\n\n")
+
         for repo_idx, repo_full_name in enumerate(repos, start=1):
+            sys.stderr.write(f"\n[{repo_idx}/{total_repos}] Processing: {repo_full_name}\n")
+            
             items = self.search_files(session, org, repo_full_name)
             total_files = len(items)
+            
             if total_files == 0:
-                # Indicate that no go.sum file was found
                 print_table(repo_full_name, [], "No go.sum file found")
                 continue
+
+            sys.stderr.write(f"[{repo_full_name}] Analyzing {total_files} file(s)...\n")
 
             for idx, item in enumerate(items, start=1):
                 repo_full = item.get("repository", {}).get("full_name", "")
                 path = item.get("path", "")
                 html_url = item.get("html_url", "")
+                
                 if repo_full:
                     unique_repos.add(repo_full)
+
+                sys.stderr.write(f"[{repo_full_name}] Fetching: {path}\n")
 
                 fetched = self.fetch_content(session, item)
                 if not fetched:
                     continue
 
                 dependencies = self.parse_dependencies(fetched)
+                sys.stderr.write(f"[{repo_full_name}] Found {len(dependencies)} total dependencies in {path}\n")
+                
                 matches = self.find_matches(dependencies, targets)
+                
+                if matches:
+                    sys.stderr.write(f"[{repo_full_name}] ⚠️  VULNERABLE: Found {len(matches)} matching vulnerable module(s) in {path}\n")
+                else:
+                    sys.stderr.write(f"[{repo_full_name}] ✓ No vulnerable modules found in {path}\n")
 
                 results.append({
                     "repo": repo_full,
@@ -125,16 +249,19 @@ class GoDetector(BaseDetector):
                     "matches": matches,
                 })
 
-                if idx % 25 == 0:
-                    sys.stderr.write(f"Scanned {idx}/{total_files} files in {repo_full_name}...\n")
+                total_files_scanned += 1
+                
+                # Add small delay between content fetches
+                time.sleep(self.content_delay)
 
-            # Add a small delay between processing each repository
-            time.sleep(3)
+            sys.stderr.write(f"[{repo_idx}/{total_repos}] Completed: {repo_full_name}\n")
 
-            # Update progress output to include current repository and overall progress
-            sys.stderr.write(f"Processed {repo_idx}/{total_repos} repositories: {repo_full_name}\n")
-
-        sys.stderr.write("Scanning complete. All files have been processed.\n")
+        sys.stderr.write(f"\n{'='*80}\n")
+        sys.stderr.write(f"Scan complete!\n")
+        sys.stderr.write(f"Total repositories scanned: {total_repos}\n")
+        sys.stderr.write(f"Total files analyzed: {total_files_scanned}\n")
+        sys.stderr.write(f"Repositories with go.sum: {len(unique_repos)}\n")
+        sys.stderr.write(f"{'='*80}\n\n")
 
         return unique_repos, results, total_files_scanned
 

--- a/detectors/go_detector.py
+++ b/detectors/go_detector.py
@@ -188,7 +188,7 @@ class GoDetector(BaseDetector):
         target_set = set(targets)
         return [(module, version) for module, version in dependencies if (module, version) in target_set]
 
-    def process_repositories(self, session: requests.Session, org: str, repo_type: str, targets: List[Tuple[str, str]], include_archived: bool = False) -> Tuple[Set[str], List[dict], int, List[str]]:  # NUEVO: parámetro
+    def process_repositories(self, session: requests.Session, org: str, repo_type: str, targets: List[Tuple[str, str]], include_archived: bool = False) -> Tuple[Set[str], List[dict], int, List[str]]:
         """Process all repositories in the organization"""
         unique_repos: Set[str] = set()
         results: List[dict] = []
@@ -198,10 +198,10 @@ class GoDetector(BaseDetector):
         sys.stderr.write(f"Starting scan for organization: {org}\n")
         sys.stderr.write(f"Repository type: {repo_type}\n")
         sys.stderr.write(f"Target modules: {len(targets)}\n")
-        sys.stderr.write(f"Include archived: {include_archived}\n")  # NUEVO: log
+        sys.stderr.write(f"Include archived: {include_archived}\n")
         sys.stderr.write(f"{'='*80}\n\n")
 
-        repos = list_all_repositories(session, org, repo_type, include_archived)  # NUEVO: pasar parámetro
+        repos = list_all_repositories(session, org, repo_type, include_archived)
         total_repos = len(repos)
         
         sys.stderr.write(f"Found {total_repos} repositories to scan\n\n")

--- a/detectors/npm_detector.py
+++ b/detectors/npm_detector.py
@@ -1,107 +1,256 @@
 import json
 import base64
-import requests
 import sys
 import time
 from typing import List, Tuple, Dict, Optional, Set
 from config import GITHUB_API
-from utils.report_generator import make_markdown_report
 from .base_detector import BaseDetector
-from utils.github_utils import list_all_repositories
+from utils.github_utils import list_all_repositories, http_get
 from utils.report_generator import print_table
 
 
 class NpmDetector(BaseDetector):
-    def search_files(self, session: requests.Session, org: str, repo_full_name: str) -> List[dict]:
+    def __init__(self):
+        self.search_delay = 2  # seconds between search requests
+        self.content_delay = 0.1  # seconds between content fetches
+        
+    def search_files(self, session, org: str, repo_full_name: str) -> Tuple[List[dict], bool]:
+        """
+        Search for package-lock.json using two strategies:
+        1. Code Search API (fast but may fail on large repos)
+        2. Contents API fallback (slower but reliable)
+        
+        Returns: (items, has_package_json)
+        """
+        # Strategy 1: Try Code Search API first
+        items = self._search_via_code_api(session, repo_full_name)
+        
+        if items:
+            sys.stderr.write(f"[{repo_full_name}] Found {len(items)} package-lock.json file(s) via Code Search API\n")
+            return items, False  # We don't know about package.json from Code Search
+        
+        # Strategy 2: Fallback to Contents API
+        sys.stderr.write(f"[{repo_full_name}] Code Search returned 0 results, trying Contents API...\n")
+        items, has_package_json = self._search_via_contents_api(session, repo_full_name)
+        
+        if items:
+            sys.stderr.write(f"[{repo_full_name}] Found {len(items)} package-lock.json file(s) via Contents API\n")
+        
+        return items, has_package_json
+
+    def _search_via_code_api(self, session, repo_full_name: str) -> List[dict]:
+        """Search using Code Search API (may fail on large repos)"""
         items = []
         page = 1
+        
         while True:
             params = {
-                "q": f"org:{org} repo:{repo_full_name} filename:package-lock.json",
+                "q": f"repo:{repo_full_name} filename:package-lock.json",
                 "per_page": 100,
                 "page": page,
             }
-            resp = session.get(f"{GITHUB_API}/search/code", params=params)
+            
+            resp = http_get(session, f"{GITHUB_API}/search/code", params=params)
+            
             if resp.status_code != 200:
-                sys.stderr.write(f"Search API error: {resp.status_code} {resp.text}\n")
+                if resp.status_code == 404:
+                    # Repository not found or not accessible
+                    break
+                sys.stderr.write(f"[{repo_full_name}] Search API error: {resp.status_code}\n")
                 break
+                
             data = resp.json()
             page_items = data.get("items", [])
-            # Filter to ensure only exact 'package-lock.json' files are processed
             page_items = [item for item in page_items if item.get("name") == "package-lock.json"]
+            
             if not page_items:
                 break
+                
             items.extend(page_items)
             page += 1
+            
+            if page_items:
+                time.sleep(self.search_delay)
+        
         return items
 
-    def fetch_content(self, session: requests.Session, item: dict) -> Optional[str]:
+    def _search_via_contents_api(self, session, repo_full_name: str) -> Tuple[List[dict], bool]:
+        """
+        Fallback using Contents API.
+        Search in common locations used by Mattermost repositories.
+        
+        Returns: (items, has_package_json)
+        """
+        items = []
+        has_package_json = False
+        
+        # Common paths in Mattermost repositories
+        common_paths = [
+            "",                    # root
+            "webapp",              
+        ]
+        
+        not_found_count = 0
+        
+        for path in common_paths:
+            # Check for package.json first
+            package_json_path = f"{path}/package.json" if path else "package.json"
+            package_json_url = f"{GITHUB_API}/repos/{repo_full_name}/contents/{package_json_path}"
+            resp_pkg = http_get(session, package_json_url, suppress_404=True)
+            
+            if resp_pkg.status_code == 200:
+                has_package_json = True
+            
+            # Then check for package-lock.json
+            file_path = f"{path}/package-lock.json" if path else "package-lock.json"
+            url = f"{GITHUB_API}/repos/{repo_full_name}/contents/{file_path}"
+            
+            resp = http_get(session, url, suppress_404=True)
+            
+            if resp.status_code == 200:
+                data = resp.json()
+                
+                # Convert Contents API format to Search API format
+                item = {
+                    "name": "package-lock.json",
+                    "path": file_path,
+                    "sha": data.get("sha"),
+                    "url": data.get("url"),
+                    "html_url": data.get("html_url"),
+                    "repository": {
+                        "full_name": repo_full_name
+                    }
+                }
+                items.append(item)
+                sys.stderr.write(f"[{repo_full_name}] Found: {file_path}\n")
+            elif resp.status_code == 404:
+                not_found_count += 1
+            else:
+                # Log other errors
+                sys.stderr.write(f"[{repo_full_name}] Unexpected error {resp.status_code} while checking {file_path}\n")
+            
+            time.sleep(self.content_delay)
+        
+        # Show summary message if nothing was found
+        if not items and not_found_count > 0:
+            if has_package_json:
+                sys.stderr.write(f"[{repo_full_name}] ⚠️  Has package.json but no package-lock.json found\n")
+            else:
+                sys.stderr.write(f"[{repo_full_name}] Checked {len(common_paths)} common locations, no package-lock.json found\n")
+        
+        return items, has_package_json
+
+    def fetch_content(self, session, item: dict) -> Optional[str]:
+        """Fetch and decode the content of a file"""
         contents_url = item.get("url")
         sha = item.get("sha")
+        repo_full_name = item.get("repository", {}).get("full_name", "unknown")
+        path = item.get("path", "")
+        
         if not contents_url:
             repo = item.get("repository", {}).get("full_name")
-            path = item.get("path")
             if not repo or not path:
                 return None
             contents_url = f"{GITHUB_API}/repos/{repo}/contents/{path}"
 
         url = contents_url if "?" in contents_url else contents_url + (f"?ref={sha}" if sha else "")
 
-        resp = session.get(url)
+        resp = http_get(session, url)
+        
         if resp.status_code != 200:
-            sys.stderr.write(f"Failed to fetch contents: {resp.status_code} {url}\n")
+            sys.stderr.write(f"[{repo_full_name}] Failed to fetch {path}: HTTP {resp.status_code}\n")
             return None
 
         payload = resp.json()
         if not isinstance(payload, dict):
             return None
+            
         encoding = payload.get("encoding")
         content_b64 = payload.get("content")
+        
         if encoding != "base64" or not content_b64:
+            sys.stderr.write(f"[{repo_full_name}] Invalid encoding for {path}\n")
             return None
+            
         try:
             raw = base64.b64decode(content_b64).decode("utf-8", errors="replace")
             return raw
         except Exception as e:
-            sys.stderr.write(f"Error decoding/parsing content from {url}: {e}\n")
+            sys.stderr.write(f"[{repo_full_name}] Error decoding {path}: {e}\n")
             return None
 
-    def parse_dependencies(self, content: str) -> List[Tuple[str, str]]:
-        lock = json.loads(content)
-        return collect_occurrences(lock)
+    def parse_dependencies(self, content: str) -> List[Tuple[str, str, str]]:
+        """Parse package-lock.json and extract dependencies"""
+        try:
+            lock = json.loads(content)
+            return collect_occurrences(lock)
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"Error parsing package-lock.json: {e}\n")
+            return []
 
-    def find_matches(self, dependencies: List[Tuple[str, str]], targets: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
+    def find_matches(self, dependencies: List[Tuple[str, str, str]], targets: List[Tuple[str, str]]) -> List[Tuple[str, str, str]]:
+        """Find dependencies matching target versions"""
         target_set: Set[Tuple[str, str]] = set((n, v) for n, v in targets)
         return [(n, v, w) for (n, v, w) in dependencies if (n, v) in target_set]
 
-    def process_repositories(self, session: requests.Session, org: str, repo_type: str, targets: List[Tuple[str, str]]) -> Tuple[Set[str], List[dict], int]:
+    def process_repositories(self, session, org: str, repo_type: str, targets: List[Tuple[str, str]], include_archived: bool = False) -> Tuple[Set[str], List[dict], int, List[str]]:
+        """Process all repositories in the organization"""
         unique_repos: Set[str] = set()
         results: List[dict] = []
         total_files_scanned = 0
+        repos_with_package_json_only: List[str] = []
 
-        repos = list_all_repositories(session, org, repo_type)
+        sys.stderr.write(f"\n{'='*80}\n")
+        sys.stderr.write(f"Starting scan for organization: {org}\n")
+        sys.stderr.write(f"Repository type: {repo_type}\n")
+        sys.stderr.write(f"Target packages: {len(targets)}\n")
+        sys.stderr.write(f"Include archived: {include_archived}\n")
+        sys.stderr.write(f"{'='*80}\n\n")
+
+        repos = list_all_repositories(session, org, repo_type, include_archived)
         total_repos = len(repos)
+        
+        sys.stderr.write(f"Found {total_repos} repositories to scan\n\n")
+        
         for repo_idx, repo_full_name in enumerate(repos, start=1):
-            items = self.search_files(session, org, repo_full_name)
+            sys.stderr.write(f"\n[{repo_idx}/{total_repos}] Processing: {repo_full_name}\n")
+            
+            items, has_package_json = self.search_files(session, org, repo_full_name)
             total_files = len(items)
+            
             if total_files == 0:
-                # Indicate that no package-lock.json file was found
-                print_table(repo_full_name, [], "No package-lock.json file found")
+                if has_package_json:
+                    repos_with_package_json_only.append(repo_full_name)
+                    print_table(repo_full_name, [], "⚠️  Has package.json but no package-lock.json")
+                else:
+                    print_table(repo_full_name, [], "No package-lock.json file found")
                 continue
+
+            sys.stderr.write(f"[{repo_full_name}] Analyzing {total_files} file(s)...\n")
 
             for idx, item in enumerate(items, start=1):
                 repo_full = item.get("repository", {}).get("full_name", "")
                 path = item.get("path", "")
                 html_url = item.get("html_url", "")
+                
                 if repo_full:
                     unique_repos.add(repo_full)
 
+                sys.stderr.write(f"[{repo_full_name}] Fetching: {path}\n")
+                
                 fetched = self.fetch_content(session, item)
                 if not fetched:
                     continue
 
                 dependencies = self.parse_dependencies(fetched)
+                sys.stderr.write(f"[{repo_full_name}] Found {len(dependencies)} total dependencies in {path}\n")
+                
                 matches = self.find_matches(dependencies, targets)
+                
+                if matches:
+                    sys.stderr.write(f"[{repo_full_name}] ⚠️  VULNERABLE: Found {len(matches)} matching vulnerable package(s) in {path}\n")
+                else:
+                    sys.stderr.write(f"[{repo_full_name}] ✓ No vulnerable packages found in {path}\n")
 
                 results.append({
                     "repo": repo_full,
@@ -110,18 +259,22 @@ class NpmDetector(BaseDetector):
                     "matches": matches,
                 })
 
-                if idx % 25 == 0:
-                    sys.stderr.write(f"Scanned {idx}/{total_files} files in {repo_full_name}...\n")
+                total_files_scanned += 1
+                
+                # Add small delay between content fetches
+                time.sleep(self.content_delay)
 
-            # Add a small delay between processing each repository
-            time.sleep(3)
+            sys.stderr.write(f"[{repo_idx}/{total_repos}] Completed: {repo_full_name}\n")
 
-            # Update progress output to include current repository and overall progress
-            sys.stderr.write(f"Processed {repo_idx}/{total_repos} repositories: {repo_full_name}\n")
-
-        sys.stderr.write("Scanning complete. All files have been processed.\n")
-
-        return unique_repos, results, total_files_scanned
+        sys.stderr.write(f"\n{'='*80}\n")
+        sys.stderr.write(f"Scan complete!\n")
+        sys.stderr.write(f"Total repositories scanned: {total_repos}\n")
+        sys.stderr.write(f"Total files analyzed: {total_files_scanned}\n")
+        sys.stderr.write(f"Repositories with package-lock.json: {len(unique_repos)}\n")
+        sys.stderr.write(f"Repositories with package.json only: {len(repos_with_package_json_only)}\n")
+        sys.stderr.write(f"{'='*80}\n\n")
+        
+        return unique_repos, results, total_files_scanned, repos_with_package_json_only
 
     @property
     def file_type(self) -> str:
@@ -135,6 +288,7 @@ def collect_occurrences(lock: dict) -> List[Tuple[str, str, str]]:
     """
     v = lock.get("lockfileVersion")
     occ: List[Tuple[str, str, str]] = []
+    
     if isinstance(v, int) and v >= 2:
         occ.extend(collect_occurrences_from_v2(lock))
         if not occ:
@@ -143,6 +297,7 @@ def collect_occurrences(lock: dict) -> List[Tuple[str, str, str]]:
         occ.extend(collect_occurrences_from_v1(lock))
         if not occ:
             occ.extend(collect_occurrences_from_v2(lock))
+            
     return occ
 
 
@@ -153,8 +308,10 @@ def collect_occurrences_from_v2(lock: dict) -> List[Tuple[str, str, str]]:
     """
     occ: List[Tuple[str, str, str]] = []
     packages = lock.get("packages")
+    
     if not isinstance(packages, dict):
         return occ
+        
     for where, meta in packages.items():
         if not isinstance(meta, dict):
             continue
@@ -162,6 +319,7 @@ def collect_occurrences_from_v2(lock: dict) -> List[Tuple[str, str, str]]:
         version = meta.get("version")
         if name and version:
             occ.append((name, str(version), where or "(root)"))
+            
     return occ
 
 
@@ -172,6 +330,7 @@ def collect_occurrences_from_v1(lock: dict) -> List[Tuple[str, str, str]]:
     """
     occ: List[Tuple[str, str, str]] = []
     deps = lock.get("dependencies")
+    
     if not isinstance(deps, dict):
         return occ
 
@@ -191,16 +350,6 @@ def collect_occurrences_from_v1(lock: dict) -> List[Tuple[str, str, str]]:
     return occ
 
 
-def find_matches(occurrences: List[Tuple[str, str, str]],
-                 targets: List[Tuple[str, str]]) -> List[Tuple[str, str, str]]:
-    """
-    Filter occurrences to only those matching exact package@version in targets.
-    Returns list of (name, version, where).
-    """
-    target_set: Set[Tuple[str, str]] = set((n, v) for n, v in targets)
-    return [(n, v, w) for (n, v, w) in occurrences if (n, v) in target_set]
-
-
 def derive_name_from_path_key(path_key: str) -> Optional[str]:
     """
     Given a 'packages' key from lockfile v2 like:
@@ -209,6 +358,7 @@ def derive_name_from_path_key(path_key: str) -> Optional[str]:
     """
     if not path_key:
         return None
+        
     parts = path_key.split("node_modules/")
     tail = parts[-1] if parts else path_key
     tail = tail.strip("/")

--- a/dh.py
+++ b/dh.py
@@ -1,19 +1,14 @@
 #!/usr/bin/env python3
 
 import argparse
-import base64
-import json
-import os
 import sys
-import time
-from typing import Dict, List, Tuple, Set, Iterable, Optional
+from typing import List, Tuple, Set
 
 import requests
 
 from detectors.npm_detector import NpmDetector
 from detectors.go_detector import GoDetector
-from config import GITHUB_API
-from utils.github_utils import get_token, http_get, list_all_repositories
+from utils.github_utils import get_token
 from utils.report_generator import make_markdown_report
 
 
@@ -42,24 +37,19 @@ def parse_versions_file(path: str) -> List[Tuple[str, str]]:
     return targets
 
 
-def find_matches(occurrences: Iterable[Tuple[str, str, str]],
-                 targets: List[Tuple[str, str]]) -> List[Tuple[str, str, str]]:
-    """
-    Filter occurrences to only those matching exact package@version in targets.
-    Returns list of (name, version, where).
-    """
-    target_set: Set[Tuple[str, str]] = set((n, v) for n, v in targets)
-    return [(n, v, w) for (n, v, w) in occurrences if (n, v) in target_set]
-
-
 def add_common_flags(parser: argparse.ArgumentParser) -> None:
+    """Add common command-line arguments to the parser."""
     parser.add_argument("--account", required=True, help="GitHub user or organization name")
     parser.add_argument("--versions", required=True, help="Path to versions.txt (format: name@version per line)")
     parser.add_argument("--debug", action="store_true", help="Print debug info for target packages found at any version")
     parser.add_argument("--repo-type", choices=["public", "private"], default="all", help="Specify the type of repositories to scan: public or private (default: all)")
+    parser.add_argument("--include-archived", action="store_true", help="Include archived repositories in scan (default: exclude archived repos)") 
 
 
 def setup_session(token: str) -> requests.Session:
+    """
+    Setup a requests session with GitHub authentication.
+    """
     session = requests.Session()
     session.headers.update({
         "Authorization": f"Bearer {token}",
@@ -69,15 +59,17 @@ def setup_session(token: str) -> requests.Session:
     return session
 
 
-def generate_report(org: str, targets: List[Tuple[str, str]], results: List[dict], total_files_scanned: int, unique_repos: Set[str]) -> None:
-    sys.stderr.write("Scanning complete. All files have been processed.\n")
-    report_md = make_markdown_report(org, targets, results, total_files_scanned, unique_repos)
-    print(report_md)
-
-
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Scan GitHub org for dependencies and match target package versions.")
-    parser.add_argument('--detector', choices=['npm', 'go'], required=True, help='Specify the type of detector to use: npm or go')
+    """Main entry point for the dependency scanner."""
+    parser = argparse.ArgumentParser(
+        description="Scan GitHub org for dependencies and match target package versions."
+    )
+    parser.add_argument(
+        '--detector', 
+        choices=['npm', 'go'], 
+        required=True, 
+        help='Specify the type of detector to use: npm or go'
+    )
     add_common_flags(parser)
 
     args = parser.parse_args()
@@ -97,8 +89,19 @@ def main() -> None:
         sys.exit(1)
 
     # Process repositories and generate report
-    unique_repos, results, total_files_scanned = detector.process_repositories(session, args.account, args.repo_type, targets)
-    report_md = make_markdown_report(args.account, targets, results, total_files_scanned, unique_repos, detector.file_type)
+    unique_repos, results, total_files_scanned, repos_with_special_case = detector.process_repositories(
+        session, args.account, args.repo_type, targets, args.include_archived
+    )
+    
+    report_md = make_markdown_report(
+        args.account, 
+        targets, 
+        results, 
+        total_files_scanned, 
+        unique_repos, 
+        detector.file_type,
+        repos_with_special_case
+    )
     print(report_md)
 
 

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -143,7 +143,7 @@ def http_get(session: requests.Session, url: str, params: Optional[dict] = None,
     return resp
 
 
-def list_all_repositories(session: requests.Session, account: str, repo_type: str, include_archived: bool = False) -> List[str]:  # NUEVO: parámetro
+def list_all_repositories(session: requests.Session, account: str, repo_type: str, include_archived: bool = False) -> List[str]:
     """
     List all repositories for a GitHub user or organization based on the specified type.
     Includes rate limit awareness.

--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -14,63 +14,152 @@ def get_token() -> str:
     return tok
 
 
-def http_get(session: requests.Session, url: str, params: Optional[dict] = None, max_retries: int = 5) -> requests.Response:
-    """GET with basic retry and rate-limit handling."""
+def check_rate_limit(session: requests.Session) -> dict:
+    """Check current rate limit status."""
+    resp = session.get(f"{GITHUB_API}/rate_limit")
+    if resp.status_code == 200:
+        return resp.json()
+    return {}
+
+
+def wait_for_rate_limit_reset(session: requests.Session, resource: str = "core") -> None:
+    """
+    Wait until the rate limit resets for the specified resource.
+    """
+    rate_info = check_rate_limit(session)
+    if not rate_info:
+        sys.stderr.write("Could not check rate limit, waiting 60s...\n")
+        time.sleep(60)
+        return
+    
+    resources = rate_info.get("resources", {})
+    resource_info = resources.get(resource, {})
+    
+    remaining = resource_info.get("remaining", 0)
+    reset_time = resource_info.get("reset", 0)
+    
+    if remaining == 0:
+        now = int(time.time())
+        sleep_duration = max(5, reset_time - now + 5)  # Add 5s buffer
+        sys.stderr.write(f"Rate limit exhausted for '{resource}'. Waiting {sleep_duration}s until reset...\n")
+        time.sleep(sleep_duration)
+    elif remaining < 10:
+        sys.stderr.write(f"Rate limit low ({remaining} remaining). Slowing down requests...\n")
+        time.sleep(2)
+
+
+def http_get(session: requests.Session, url: str, params: Optional[dict] = None, max_retries: int = 5, suppress_404: bool = False) -> requests.Response:
+    """
+    GET with comprehensive retry and rate-limit handling.
+    
+    Implements:
+    - Primary rate limit detection and handling
+    - Secondary rate limit (abuse detection) handling
+    - Exponential backoff for transient errors
+    - Proactive rate limit checking for search endpoints
+    """
     backoff = 1.5
+    
+    # Proactive rate limit check for search API
+    if url and "search" in url:
+        wait_for_rate_limit_reset(session, "search")
+    
     for attempt in range(max_retries):
-        resp = session.get(url, params=params)
+        try:
+            resp = session.get(url, params=params, timeout=30)
+        except requests.exceptions.Timeout:
+            sleep_for = min(60, int(backoff ** (attempt + 1)))
+            sys.stderr.write(f"Request timeout. Retrying in {sleep_for}s...\n")
+            time.sleep(sleep_for)
+            continue
+        except requests.exceptions.RequestException as e:
+            sys.stderr.write(f"Request error: {e}. Retrying...\n")
+            time.sleep(5)
+            continue
+        
         if resp.status_code == 200:
             return resp
 
-        # Rate limit
-        if resp.status_code == 403 and resp.headers.get("X-RateLimit-Remaining") == "0":
-            reset = resp.headers.get("X-RateLimit-Reset")
-            now = int(time.time())
-            sleep_for = max(5, int(reset) - now) if reset and reset.isdigit() else 60
-            sys.stderr.write(f"Rate limited. Sleeping {sleep_for}s until reset...\n")
-            time.sleep(sleep_for)
-            continue
-
-        # Secondary rate limit or abuse detection
-        if resp.status_code in (403, 429):
+        # Primary rate limit (403 with X-RateLimit-Remaining: 0)
+        if resp.status_code == 403:
+            remaining = resp.headers.get("X-RateLimit-Remaining")
+            
+            if remaining == "0":
+                reset = resp.headers.get("X-RateLimit-Reset")
+                now = int(time.time())
+                sleep_for = max(5, int(reset) - now + 5) if reset and reset.isdigit() else 60
+                sys.stderr.write(f"Primary rate limit hit. Sleeping {sleep_for}s until reset...\n")
+                time.sleep(sleep_for)
+                continue
+            
+            # Secondary rate limit (abuse detection)
             retry_after = resp.headers.get("Retry-After")
             if retry_after and retry_after.isdigit():
-                sleep_for = int(retry_after)
-            else:
-                sleep_for = min(60, int(backoff ** (attempt + 1)))
-            sys.stderr.write(f"HTTP {resp.status_code}. Backing off {sleep_for}s...\n")
+                sleep_for = int(retry_after) + 5  # Add buffer
+                sys.stderr.write(f"Secondary rate limit (403). Sleeping {sleep_for}s as indicated by Retry-After...\n")
+                time.sleep(sleep_for)
+                continue
+            
+            # Generic 403 without clear rate limit headers
+            sleep_for = min(120, int(backoff ** (attempt + 2)))
+            sys.stderr.write(f"HTTP 403 (possible abuse detection). Backing off {sleep_for}s...\n")
             time.sleep(sleep_for)
             continue
 
-        # Transient server errors
+        # Explicit rate limit response (429)
+        if resp.status_code == 429:
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after and retry_after.isdigit():
+                sleep_for = int(retry_after) + 5
+            else:
+                sleep_for = min(120, int(backoff ** (attempt + 2)))
+            sys.stderr.write(f"HTTP 429 rate limit. Backing off {sleep_for}s...\n")
+            time.sleep(sleep_for)
+            continue
+
+        # Transient server errors (5xx)
         if resp.status_code in (500, 502, 503, 504):
             sleep_for = min(60, int(backoff ** (attempt + 1)))
-            sys.stderr.write(f"HTTP {resp.status_code}. Retrying in {sleep_for}s...\n")
+            sys.stderr.write(f"HTTP {resp.status_code} server error. Retrying in {sleep_for}s...\n")
             time.sleep(sleep_for)
             continue
 
-        # Other errors - return to let caller decide
+        # Handle 404 (suppress if requested)
+        if resp.status_code == 404:
+            if not suppress_404:
+                sys.stderr.write(f"HTTP 404 client error: {resp.text[:200]}\n")
+            return resp
+
+        # Other client errors that shouldn't be retried (4xx except 403, 429, 404)
+        if 400 <= resp.status_code < 500:
+            sys.stderr.write(f"HTTP {resp.status_code} client error: {resp.text[:200]}\n")
+            return resp
+
+        # Other unexpected errors
+        sys.stderr.write(f"HTTP {resp.status_code}: {resp.text[:200]}\n")
         return resp
 
+    sys.stderr.write(f"Max retries ({max_retries}) exceeded for {url}\n")
     return resp
 
 
-def list_all_repositories(session: requests.Session, account: str, repo_type: str) -> List[str]:
+def list_all_repositories(session: requests.Session, account: str, repo_type: str, include_archived: bool = False) -> List[str]:  # NUEVO: parámetro
     """
     List all repositories for a GitHub user or organization based on the specified type.
+    Includes rate limit awareness.
     """
     repos = []
     page = 1
-    is_org = False
+    archived_count = 0
 
     # Determine if the account is a user or an organization
-    resp = session.get(f"{GITHUB_API}/users/{account}")
-    if resp.status_code == 200:
-        user_data = resp.json()
-        is_org = user_data.get('type') == 'Organization'
-    else:
+    resp = http_get(session, f"{GITHUB_API}/users/{account}")
+    if resp.status_code != 200:
         sys.stderr.write(f"Failed to determine account type: {resp.status_code} {resp.text}\n")
         return repos
+    
+    user_data = resp.json()
+    is_org = user_data.get('type') == 'Organization'
 
     # Use the appropriate endpoint
     endpoint = f"{GITHUB_API}/orgs/{account}/repos" if is_org else f"{GITHUB_API}/users/{account}/repos"
@@ -79,15 +168,39 @@ def list_all_repositories(session: requests.Session, account: str, repo_type: st
         params = {
             "per_page": 100,
             "page": page,
-            "type": repo_type if repo_type != "all" else None,
         }
+        
+        # Add type filter if specified
+        if repo_type != "all":
+            params["type"] = repo_type
+        
         resp = http_get(session, endpoint, params=params)
+        
         if resp.status_code != 200:
             sys.stderr.write(f"Failed to list repositories: {resp.status_code} {resp.text}\n")
             break
+            
         data = resp.json()
         if not data:
             break
-        repos.extend(repo["full_name"] for repo in data)
+        
+        for repo in data:
+            if repo.get("archived", False):
+                archived_count += 1
+                if not include_archived:
+                    continue  # Skip archived repos
+            repos.append(repo["full_name"])
+        
         page += 1
+        
+        # Small delay between pages to be respectful
+        if len(data) == 100:  # Only delay if there might be more pages
+            time.sleep(0.5)
+    
+    if archived_count > 0:
+        if include_archived:
+            sys.stderr.write(f"Found {archived_count} archived repositories (included in scan)\n")
+        else:
+            sys.stderr.write(f"Excluded {archived_count} archived repositories from scan\n")
+    
     return repos

--- a/utils/report_generator.py
+++ b/utils/report_generator.py
@@ -1,78 +1,124 @@
 from typing import List, Tuple, Dict, Set
 
 
+from typing import List, Tuple, Dict, Set
+
+
 def make_markdown_report(
     org: str,
     targets: List[Tuple[str, str]],
     results: List[dict],
     total_files_scanned: int,
     unique_repos: Set[str],
-    file_type: str
+    file_type: str,
+    repos_with_package_json_only: List[str] = []
 ) -> str:
     """
     Build the final Markdown report string for dependencies.
-    results entries: {
-        'repo': 'owner/name',
-        'path': 'path/to/file',
-        'html_url': 'https://github.com/.../file',
-        'matches': [ (name, version), ... ]
-    }
     """
+    # Convert targets to string format for display
     targets_str = [f"{n}@{v}" for n, v in targets]
+    
+    # Count occurrences of each target
     occurrences_by_target: Dict[str, int] = {f"{n}@{v}": 0 for n, v in targets}
+    
     for r in results:
-        for (n, v) in r["matches"]:
-            occurrences_by_target[f"{n}@{v}"] = occurrences_by_target.get(f"{n}@{v}", 0) + 1
+        for match in r["matches"]:
+            # Handle both tuple formats: (name, version) and (name, version, where)
+            if len(match) >= 2:
+                n, v = match[0], match[1]
+                key = f"{n}@{v}"
+                occurrences_by_target[key] = occurrences_by_target.get(key, 0) + 1
 
+    # Start building the report
     lines: List[str] = []
+    
+    # Title
     lines.append(f"# {file_type} scan for org `{org}`")
     lines.append("")
+    
+    # Summary section
     lines.append("## Summary")
     lines.append("")
     lines.append(f"- Targets: {len(targets)} ({', '.join(targets_str)})")
     lines.append(f"- Repositories scanned (unique): {len(unique_repos)}")
     lines.append(f"- {file_type} files scanned: {total_files_scanned}")
     lines.append(f"- Files with at least one match: {sum(1 for r in results if r['matches'])}")
+    
+    # Add warning section for repos with package.json only (npm specific)
+    if repos_with_package_json_only:
+        lines.append(f"- ⚠️  Repositories with package.json but no package-lock.json: {len(repos_with_package_json_only)}")
+    
     lines.append("")
+    
+    # Target occurrence counts table
     lines.append("### Target occurrence counts")
     lines.append("")
     lines.append("| Name@Version | Occurrences |")
     lines.append("|---|---|")
     for t in targets_str:
-        lines.append(f"| `{t}` | {occurrences_by_target.get(t, 0)} |")
+        count = occurrences_by_target.get(t, 0)
+        lines.append(f"| `{t}` | {count} |")
     lines.append("")
 
+    # Detailed matches section
     lines.append("## Detailed matches")
     lines.append("")
-    lines.append("| Repository | Path | Name | Version | Count in file | Example location | Link | Note |")
-    lines.append("|---|---|---:|---|---|---:|---|---|---|")
+    lines.append("| Repository | Path | Name | Version | Count in file | Example location | Link |")
+    lines.append("|---|---|---|---|---|---|---|")
+    
     any_match = False
     for r in results:
-        if not r["matches"] and "note" in r:
-            lines.append(f"| `{r['repo']}` | `{r['path']}` |  |  |  |  | {r['note']} |")
-            continue
         if not r["matches"]:
             continue
+            
         any_match = True
+        repo = r['repo']
+        path = r['path']
+        html_url = r['html_url']
+        
+        # Group matches by (name, version)
         per_target: Dict[Tuple[str, str], List[str]] = {}
-        for (n, v) in r["matches"]:
-            per_target.setdefault((n, v), []).append(r['path'])
+        for match in r["matches"]:
+            # Handle both tuple formats: (name, version, where) or (name, version)
+            if len(match) >= 3:
+                n, v, where = match[0], match[1], match[2]
+            else:
+                n, v = match[0], match[1]
+                where = "(unknown)"
+            per_target.setdefault((n, v), []).append(where)
+        
+        # Add a row for each unique (name, version) pair found in this file
         for (n, v), wheres in sorted(per_target.items()):
             count = len(wheres)
             example = wheres[0]
             lines.append(
-                f"| `{r['repo']}` | `{r['path']}` | `{n}` | `{v}` | {count} | `{example}` | [view]({r['html_url']}) |"
+                f"| `{repo}` | `{path}` | `{n}` | `{v}` | {count} | `{example}` | [view]({html_url}) |"
             )
+    
     if not any_match:
-        lines.append("_No matches found._")
+        lines.append("| | | | | | | _No matches found._ |")
     lines.append("")
 
+    # List targets with zero occurrences
     zeroes = [t for t, c in occurrences_by_target.items() if c == 0]
     if zeroes:
         lines.append("## Targets with zero occurrences")
         lines.append("")
         for t in zeroes:
             lines.append(f"- `{t}`")
+        lines.append("")
+
+    # Add section for repos with package.json but no lockfile (npm specific)
+    if repos_with_package_json_only:
+        lines.append("## ⚠️  Repositories with package.json but no package-lock.json")
+        lines.append("")
+        lines.append("These repositories contain Node.js projects but lack a lockfile. **Cannot verify exact dependency versions.**")
+        lines.append("")
+        lines.append("**Recommendation:** These repositories should be manually reviewed or developers should be asked to commit their package-lock.json files.")
+        lines.append("")
+        for repo in sorted(repos_with_package_json_only):
+            lines.append(f"- `{repo}` - https://github.com/{repo}")
         lines.append("")
 
     return "\n".join(lines)
@@ -85,6 +131,10 @@ def print_table(repo: str, data: List[Tuple[str, str, List[Tuple[str, str, str]]
     print(f"\n## Repository: {repo}\n")
     if note:
         print(f"**Note:** {note}\n")
+    
+    if not data:
+        return
+        
     print("| Package | Vulnerable Version | Found Versions | Repository |")
     print("|---|---|---|---|")
     for package, vuln_version, found_versions in data:


### PR DESCRIPTION
- Fixed the search to use the Content GitHub API as a fallback when the Search API does not find package-lock.json.
- Made the code rate-limit friendly so we don't hit GitHub API limits
- Detect repos with package.json but missing package-lock.json (can't verify versions on those) + adding them in the final report
- Skips archived repos by default (add --include-archived if you need them)
- Added a bit more of information in the console output to enhance tracking and be able to know what's happening during the scan
- Report now includes links directly to the vulnerable files on GitHub